### PR TITLE
chore: update hugo version to v0145.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-HUGO_VERSION := 0.135.0
+HUGO_VERSION := 0.145.0
 HUGO := ./.bin/hugo
 
 # OSとアーキテクチャの検出


### PR DESCRIPTION
# 概要

Hugo のバージョンを v145.0 にあげる。

v145.0 までは問題なくあがるのだが、146.0 にアップデートするとテンプレートシステムの読み込み周りに失敗しビルドできない 😇 